### PR TITLE
Adding filtering and labels to frontend

### DIFF
--- a/frontend/src/components/DisplayDriver.vue
+++ b/frontend/src/components/DisplayDriver.vue
@@ -6,14 +6,10 @@
     const driversName = ref(runs[0].driverName);
     const carNumber = ref(runs[0].carNumber);
     const carClass = ref(runs[0].carClass);
-    const bestRawTime = ref(Math.min(...runs.map(run => run.rawTime)));
-    const bestPaxTime = ref(Math.min(...runs.map(run => run.paxTime)));
 </script>
 
 <template>
     <p>Driver: {{ driversName }}</p>
     <p>Car Number: {{ carNumber }}</p>
     <p>Car Class: {{ carClass }}</p>
-    <p>Best Raw Time: {{ bestRawTime }}</p>
-    <p>Best Pax Time: {{ bestPaxTime }}</p>
 </template>

--- a/frontend/src/components/DisplayRuns.vue
+++ b/frontend/src/components/DisplayRuns.vue
@@ -4,18 +4,72 @@
     const props = defineProps(['runs', 'displayType', 'sortType']);
 
     function sort(runs, sortType){
-        if(sortType === "raw"){
-            const newRuns = [].slice.call(runs).sort((a, b) => a.rawTime - b.rawTime);
-            return newRuns;
+        // sort by created time
+        if (sortType === undefined) {
+            const newRuns = [].slice.call(runs).sort((a, b) => {
+                const runCreateA = Number(a.created);
+                const runCreateB = Number(b.created);
+                if (runCreateA < runCreateB) {
+                    return 1;
+                }
+                if (runCreateA > runCreateB) {
+                    return -1;
+                }
+                return 0;
+            });
+            return newRuns
         }
-        else if(sortType === "pax"){
-            const newRuns = [].slice.call(runs).sort((a, b) => a.paxTime - b.paxTime);
-            return newRuns;
-        }
-        else {
-            return runs;
-        }
-    };
+
+        // sort by run time, only show fastest per-car
+        const newRuns = [].slice.call(runs).sort((a, b) => {
+            const timeA = Number(sortType == 'raw' ? a.rawTime : a.paxTime);
+            const timeB = Number(sortType == 'raw' ? b.rawTime : b.paxTime);
+
+            // Add 2 seconds per cone
+            const timePenA = Number(a.cones * 2);
+            const timePenB = Number(b.cones * 2);
+
+            if (timeA + timePenA > timeB + timePenB) {
+                return 1;
+            }
+            if (timeA + timePenA < timeB + timePenB) {
+                return -1;
+            }
+            return 0;
+        });
+
+        // filter to only fastest run
+        const cars_seen = []
+        const filterRuns = newRuns.filter((run) => {
+            if (cars_seen.includes(run.carNumber)) {
+                return false
+            }
+            cars_seen.push(run.carNumber)
+            return true
+        });
+        return filterRuns
+    }
+
+    function individualmeta(runs){
+        // Find best run
+        var best_time = 999999999
+        runs.forEach((run) => {
+            const runTime = Number(run.rawTime) + run.cones * 2;
+            if (runTime < best_time && run.isDnf!==1 && run.getsRerun!==1) {
+                if (best_time !== 999999999) {
+                    run.delta = Math.round((best_time - runTime) * 1000) / 1000
+                }
+                best_time = runTime
+            }
+        });
+        runs.forEach((run) => {
+            const runTime = Number(run.rawTime) + run.cones * 2;
+            if (runTime == best_time) {
+                run.best = 1
+            }
+        });
+        return runs
+    }
 </script>
 
 <template>
@@ -24,13 +78,14 @@
     </div>
     <div v-if="runs" class="content">
         <div v-if="displayType==='individual-car'">
-            <p class="run-container" v-for="(run, index) in runs" :key="runs.runNumber">
-                <span class="run-number">{{ index+1 }}</span>
+            <p class="run-container" v-for="(run, index) in individualmeta(runs)" :key="runs.runNumber">
+                <span class="run-number">Run {{ index+1 }}</span>
                 <span class="run-name">{{ run.driverName }}</span>
                 <template v-if="run.isDnf!==1 && run.getsRerun!==1">
                     <span class="right">
-                        <span v-if="run.cones" class="run-cones">+{{ run.cones }}</span>
-                        <span class="run-paxtime">{{ run.paxTime }}</span>
+                        <span v-if="run.cones >= 2" class="run-cones">+{{ run.cones }} Cones</span>
+                        <span v-else-if="run.cones == 1" class="run-cones">+{{ run.cones }} Cone</span>
+                        <span class="run-rawtime">Raw: {{ run.rawTime }}</span>
                     </span>
                 </template>
                 <template v-else-if="run.getsRerun==1">
@@ -48,22 +103,36 @@
                 <span class="run-car-number">#{{ run.carNumber }}</span>
                 <template v-if="run.isDnf!==1 && run.getsRerun!==1">
                     <span class="right">
-                        <span class="run-rawtime">({{ run.rawTime }})</span>
+                        <span class="run_alt_time">
+                            <span class="run-paxtime">(PAX: {{ run.paxTime }})</span>
+                        </span>
                     </span>
                 </template>
+                <br/>
+                <span v-if="run.best==1" class="best-run">🔥 BEST TIME 🔥</span>
+                <template v-if="run.isDnf!==1 && run.getsRerun!==1 && run.delta > 0">
+                    <span class="right">
+                        <span class="run-delta"> NEW BEST (-{{ run.delta }})</span>
+                    </span>
+                </template>
+                <br/>
             </p>
         </div>
         <div v-else>
             <p v-for="(run, index) in sort(runs, sortType)" :key="sortType">
                 <RouterLink :to="'/event/' + run.eventId + '/car/' + run.carNumber" class="link-container">
                     <span v-if="sortType" class="run-number">{{ index+1 }}</span>
-                    <span v-else class="run-number">{{ run.runNumber }}</span>
+                    <span v-else class="run-number">Run {{ run.runNumber }}</span>
                     <span class="run-name">{{ run.driverName }}</span>
+                    <span v-if="sortType && index == 0">🥇</span>
+                    <span v-else-if="sortType && index == 1">🥈</span>
+                    <span v-else-if="sortType && index == 2">🥉</span>
                     <template v-if="run.isDnf!==1 && run.getsRerun!==1">
                         <span class="right">
-                            <span v-if="run.cones" class="run-cones">+{{ run.cones }}</span>
-                            <span v-if="sortType==='raw'" class="run-rawtime">{{ run.rawTime }}</span>
-                            <span v-else class="run-paxtime">{{ run.paxTime }}</span>
+                            <span v-if="run.cones >= 2" class="run-cones">+{{ run.cones }} Cones</span>
+                            <span v-else-if="run.cones == 1" class="run-cones">+{{ run.cones }} Cone</span>
+                            <span v-if="sortType==='raw'" class="run-rawtime">Raw {{ run.rawTime }}</span>
+                            <span v-else class="run-paxtime">PAX {{ run.paxTime }}</span>
                         </span>
                     </template>
                     <template v-else-if="run.getsRerun==1">
@@ -81,8 +150,10 @@
                     <span class="run-car-number">#{{ run.carNumber }}</span>
                     <template v-if="run.isDnf!==1 && run.getsRerun!==1">
                         <span class="right">
-                            <span v-if="sortType==='raw'" class="run-paxtime">({{ run.paxTime }})</span>
-                            <span v-else class="run-rawtime">({{ run.rawTime }})</span>
+                            <span class="run_alt_time">
+                                <span v-if="sortType==='raw'" class="run-paxtime">(PAX: {{ run.paxTime }})</span>
+                                <span v-else class="run-rawtime">(Raw: {{ run.rawTime }})</span>
+                            </span>
                         </span>
                     </template>
                 </RouterLink>
@@ -100,6 +171,18 @@
     .run-class {
         padding-right: 10px;
     }
+
+    .run_alt_time {
+        color: grey;
+    }
+
+    .run-delta {
+        color: green;
+    }
+    .best-run {
+        color: green;
+    }
+
 
     .link-container, .run-container {
         display: block;


### PR DESCRIPTION
# Changes

* Leaderboard only showing the best time per-car.
* Leaderboard adds 2 seconds per-cone for sorting purposes.
* Car page shows improvements from best runs of the day.
* Car page shows best run with 2 seconds per-cone.
* Added 'Raw' and 'PAX' labels to clarify which time is which. Setting the secondary time to a lighter colour.

# Runs:
<img width="698" height="668" alt="image" src="https://github.com/user-attachments/assets/4229f782-22e7-44ab-a3da-6c3de1c52180" />

# Leaderboard:
<img width="697" height="710" alt="image" src="https://github.com/user-attachments/assets/1701a14c-d0b2-478a-bbb3-f5e79b38a15e" />

# Car View
<img width="695" height="671" alt="image" src="https://github.com/user-attachments/assets/fe480c14-e07d-4665-b5e8-3ab2ef451b72" />
